### PR TITLE
make license unambiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ Contributions are welcome.
 
 Licensing is split by git history boundary:
 
-- **GPLv3 (FOSS):** all code up to and including tag `foss-final` (release v4.0).
+- **GPLv3-only (FOSS):** all code up to and including tag `foss-final` (release v4.0).
 - **FSL-1.1 (source-available):** commits after `foss-final` on `main`.
 
-For a fully FOSS codebase, use the `community/fdroid` branch (GPLv3).
+For a fully FOSS codebase, use the `community/fdroid` branch (GPLv3-only).
 See `LICENSE.txt` for the current branch license details.
 
 ---


### PR DESCRIPTION
@Katsuyamaki 
* i didnt touch license file, please update it also
* License: GPL-3.0-only https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/com.katsuyamaki.DroidOSFOSSLauncher.yml
* this makes license unambiguous
* inspiration: 
  * For Clarity's Sake, Please Don't Say "Licensed under GNU GPL 2"! by Richard Stallman https://www.gnu.org/licenses/identify-licenses-clearly.html
  * REUSE makes software licensing as easy as one-two-three https://fsfe.org/news/2024/news-20241114-01.en.html